### PR TITLE
Don't force cuda, allow other image edits.

### DIFF
--- a/src/edit_real.py
+++ b/src/edit_real.py
@@ -4,12 +4,18 @@ import argparse
 import numpy as np
 import torch
 import requests
+import glob
 from PIL import Image
 
 from diffusers import DDIMScheduler
 from utils.ddim_inv import DDIMInversion
 from utils.edit_directions import construct_direction
 from utils.edit_pipeline import EditingPipeline
+
+if torch.cuda.is_available():
+    device = "cuda"
+else:
+    device = "cpu"
 
 
 if __name__=="__main__":
@@ -37,7 +43,7 @@ if __name__=="__main__":
     # if the inversion is a folder, the prompt should also be a folder
     assert (os.path.isdir(args.inversion)==os.path.isdir(args.prompt)), "If the inversion is a folder, the prompt should also be a folder"
     if os.path.isdir(args.inversion):
-        l_inv_paths = sorted(glob(os.path.join(args.inversion, "*.pt")))
+        l_inv_paths = sorted(glob.glob(os.path.join(args.inversion, "*.pt")))
         l_bnames = [os.path.basename(x) for x in l_inv_paths]
         l_prompt_paths = [os.path.join(args.prompt, x.replace(".pt",".txt")) for x in l_bnames]
     else:
@@ -45,7 +51,7 @@ if __name__=="__main__":
         l_prompt_paths = [args.prompt]
 
     # Make the editing pipeline
-    pipe = EditingPipeline.from_pretrained(args.model_path, torch_dtype=torch_dtype).to("cuda")
+    pipe = EditingPipeline.from_pretrained(args.model_path, torch_dtype=torch_dtype).to(device)
     pipe.scheduler = DDIMScheduler.from_config(pipe.scheduler.config)
 
 

--- a/src/edit_synthetic.py
+++ b/src/edit_synthetic.py
@@ -10,6 +10,11 @@ from diffusers import DDIMScheduler
 from utils.edit_directions import construct_direction
 from utils.edit_pipeline import EditingPipeline
 
+if torch.cuda.is_available():
+    device = "cuda"
+else:
+    device = "cpu"
+
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser()
@@ -32,11 +37,15 @@ if __name__=="__main__":
         torch_dtype = torch.float32
 
     # make the input noise map
-    torch.cuda.manual_seed(args.random_seed)
-    x = torch.randn((1,4,64,64), device="cuda")
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(args.random_seed)
+    else:
+        torch.manual_seed(args.random_seed)
+
+    x = torch.randn((1,4,64,64), device=device)
 
     # Make the editing pipeline
-    pipe = EditingPipeline.from_pretrained(args.model_path, torch_dtype=torch_dtype).to("cuda")
+    pipe = EditingPipeline.from_pretrained(args.model_path, torch_dtype=torch_dtype).to(device)
     pipe.scheduler = DDIMScheduler.from_config(pipe.scheduler.config)
 
     rec_pil, edit_pil = pipe(args.prompt_str, 

--- a/src/utils/ddim_inv.py
+++ b/src/utils/ddim_inv.py
@@ -12,6 +12,12 @@ from base_pipeline import BasePipeline
 from cross_attention import prep_unet
 
 
+if torch.cuda.is_available():
+    device = "cuda"
+else:
+    device = "cpu"
+
+
 class DDIMInversion(BasePipeline):
 
     def auto_corr_loss(self, x, random_shift=True):
@@ -72,7 +78,7 @@ class DDIMInversion(BasePipeline):
 
         # Encode the input image with the first stage model
         x0 = np.array(img)/255
-        x0 = torch.from_numpy(x0).type(torch_dtype).permute(2, 0, 1).unsqueeze(dim=0).repeat(1, 1, 1, 1).cuda()
+        x0 = torch.from_numpy(x0).type(torch_dtype).permute(2, 0, 1).unsqueeze(dim=0).repeat(1, 1, 1, 1).to(device)
         x0 = (x0 - 0.5) * 2.
         with torch.no_grad():
             x0_enc = self.vae.encode(x0).latent_dist.sample().to(device, torch_dtype)

--- a/src/utils/edit_directions.py
+++ b/src/utils/edit_directions.py
@@ -1,6 +1,11 @@
 import os
 import torch
 
+if torch.cuda.is_available():
+    device = "cuda"
+else:
+    device = "cpu"
+
 
 """
 This function takes in a task name and returns the direction in the embedding space that transforms class A to class B for the given task.
@@ -15,15 +20,8 @@ Examples:
 >>> construct_direction("cat2dog")
 """
 def construct_direction(task_name):
-    if task_name=="cat2dog":    
-        emb_dir = f"assets/embeddings_sd_1.4"
-        embs_a = torch.load(os.path.join(emb_dir, f"cat.pt"))
-        embs_b = torch.load(os.path.join(emb_dir, f"dog.pt"))
-        return (embs_b.mean(0)-embs_a.mean(0)).unsqueeze(0)
-    elif task_name=="dog2cat":    
-        emb_dir = f"assets/embeddings_sd_1.4"
-        embs_a = torch.load(os.path.join(emb_dir, f"dog.pt"))
-        embs_b = torch.load(os.path.join(emb_dir, f"cat.pt"))
-        return (embs_b.mean(0)-embs_a.mean(0)).unsqueeze(0)
-    else:
-        raise NotImplementedError
+    (src, dst) = task_name.split("2")
+    emb_dir = f"assets/embeddings_sd_1.4"
+    embs_a = torch.load(os.path.join(emb_dir, f"{src}.pt"), map_location=device)
+    embs_b = torch.load(os.path.join(emb_dir, f"{dst}.pt"), map_location=device)
+    return (embs_b.mean(0)-embs_a.mean(0)).unsqueeze(0)

--- a/src/utils/edit_pipeline.py
+++ b/src/utils/edit_pipeline.py
@@ -9,6 +9,11 @@ from base_pipeline import BasePipeline
 from cross_attention import prep_unet
 
 
+if torch.cuda.is_available():
+    device = "cuda"
+else:
+    device = "cpu"
+
 class EditingPipeline(BasePipeline):
     def __call__(
         self,
@@ -137,7 +142,7 @@ class EditingPipeline(BasePipeline):
                     module_name = type(module).__name__
                     if module_name == "CrossAttention" and 'attn2' in name:
                         curr = module.attn_probs # size is num_channel,s*s,77
-                        ref = d_ref_t2attn[t.item()][name].detach().cuda()
+                        ref = d_ref_t2attn[t.item()][name].detach().to(device)
                         loss += ((curr-ref)**2).sum((1,2)).mean(0)
                 loss.backward(retain_graph=False)
                 opt.step()


### PR DESCRIPTION
The current version forces the use of cuda, even though the model can be practically run on a CPU.
These changes make it use cuda if available, but fallback to CPU execution if it is not.

This also avoids hard coding the allowed edits, making source modification unnecessary for adding new edit directions.