### PR TITLE
Fixed some conda environment versions to solve faster

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,13 +4,14 @@ channels:
   - nvidia
   - defaults
 dependencies:
+  - python=3.9
   - pip
   - pytorch-cuda=11.6
   - torchvision
   - pytorch
   - pip:
     - accelerate
-    - diffusers
+    - diffusers=0.14.0
     - einops
     - gradio
     - ipython


### PR DESCRIPTION
This PR set the python version to `3.9` and diffusers version to `0.14.0` to avoid the CrossAttention missing bug. Due to the version limitations the conda environment solves faster (but still takes about 1h).